### PR TITLE
Add ffmpeg-full as dependency and bump SDK version

### DIFF
--- a/org.famistudio.FamiStudio.yml
+++ b/org.famistudio.FamiStudio.yml
@@ -1,9 +1,17 @@
 app-id: org.famistudio.FamiStudio
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.dotnet7
+add-extensions:
+  org.freedesktop.Platform.ffmpeg-full:
+    version: '23.08'
+    directory: lib/ffmpeg
+    add-ld-path: .
+    autodelete: false
+cleanup-commands:
+  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 build-options:
   append-path: /usr/lib/sdk/dotnet7/bin
   append-ld-library-path: /usr/lib/sdk/dotnet7/lib


### PR DESCRIPTION
This allows the app to use the new ffmpeg build that is included in freedesktop SDK version 23.08, which is less botched than the 22.08 version and has all the codecs required to export videos.

**IMPORTANT**: BleuBleu/FamiStudio#342 must be merged first before this is ready to go. Although merging this on its own shouldn't have any undesired side effects.